### PR TITLE
Added StickySessions feature for process dipatching

### DIFF
--- a/src/config/iisnode_dev_x64.xml
+++ b/src/config/iisnode_dev_x64.xml
@@ -30,6 +30,7 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="node_env" type="string" expanded="true" defaultValue="%node_env%"/>
     <attribute name="asyncCompletionThreadCount" type="uint" defaultValue="0"/>
     <attribute name="nodeProcessCountPerApplication" type="uint" defaultValue="1"/>
+    <attribute name="nodeProcessStickySessions" type="bool" defaultValue="false"/>
     <attribute name="nodeProcessCommandLine" type="string" expanded="true" defaultValue="node.exe"/>
     <attribute name="interceptor" type="string" expanded="true" defaultValue="&quot;%programfiles(x86)%\iisnode-dev\release\x64\interceptor.js&quot;" />
     <attribute name="maxConcurrentRequestsPerProcess" type="uint" allowInfitnite="true" defaultValue="1024"/>

--- a/src/config/iisnode_dev_x86_on_x64.xml
+++ b/src/config/iisnode_dev_x86_on_x64.xml
@@ -30,6 +30,7 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="node_env" type="string" expanded="true" defaultValue="%node_env%"/>
     <attribute name="asyncCompletionThreadCount" type="uint" defaultValue="0"/>
     <attribute name="nodeProcessCountPerApplication" type="uint" defaultValue="1"/>
+    <attribute name="nodeProcessStickySessions" type="bool" defaultValue="false"/>
     <attribute name="nodeProcessCommandLine" type="string" expanded="true" defaultValue="node.exe"/>
     <attribute name="interceptor" type="string" expanded="true" defaultValue="&quot;%programfiles(x86)%\iisnode-dev\release\x86\interceptor.js&quot;" />
     <attribute name="maxConcurrentRequestsPerProcess" type="uint" allowInfitnite="true" defaultValue="1024"/>

--- a/src/config/iisnode_dev_x86_on_x86.xml
+++ b/src/config/iisnode_dev_x86_on_x86.xml
@@ -30,6 +30,7 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="node_env" type="string" expanded="true" defaultValue="%node_env%"/>
     <attribute name="asyncCompletionThreadCount" type="uint" defaultValue="0"/>
     <attribute name="nodeProcessCountPerApplication" type="uint" defaultValue="1"/>
+    <attribute name="nodeProcessStickySessions" type="bool" defaultValue="false"/>
     <attribute name="nodeProcessCommandLine" type="string" expanded="true" defaultValue="node.exe"/>
     <attribute name="interceptor" type="string" expanded="true" defaultValue="&quot;%programfiles%\iisnode-dev\release\x86\interceptor.js&quot;" />
     <attribute name="maxConcurrentRequestsPerProcess" type="uint" allowInfitnite="true" defaultValue="1024"/>

--- a/src/config/iisnode_express_schema.xml
+++ b/src/config/iisnode_express_schema.xml
@@ -30,6 +30,7 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="node_env" type="string" expanded="true" defaultValue="%node_env%"/>
     <attribute name="asyncCompletionThreadCount" type="uint" defaultValue="0"/>
     <attribute name="nodeProcessCountPerApplication" type="uint" defaultValue="1"/>
+    <attribute name="nodeProcessStickySessions" type="bool" defaultValue="false"/>
     <attribute name="nodeProcessCommandLine" type="string" expanded="true" defaultValue="node.exe"/>
     <attribute name="interceptor" type="string" expanded="true" defaultValue="&quot;%programfiles%\iisnode-express\interceptor.js&quot;" />
     <attribute name="maxConcurrentRequestsPerProcess" type="uint" allowInfitnite="true" defaultValue="1024"/>

--- a/src/config/iisnode_express_schema_x64.xml
+++ b/src/config/iisnode_express_schema_x64.xml
@@ -30,6 +30,7 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="node_env" type="string" expanded="true" defaultValue="%node_env%"/>
     <attribute name="asyncCompletionThreadCount" type="uint" defaultValue="0"/>
     <attribute name="nodeProcessCountPerApplication" type="uint" defaultValue="1"/>
+    <attribute name="nodeProcessStickySessions" type="bool" defaultValue="false"/>
     <attribute name="nodeProcessCommandLine" type="string" expanded="true" defaultValue="node.exe"/>
     <attribute name="interceptor" type="string" expanded="true" defaultValue="&quot;%programfiles(x86)%\iisnode-express\interceptor.js&quot;" />
     <attribute name="maxConcurrentRequestsPerProcess" type="uint" allowInfitnite="true" defaultValue="1024"/>

--- a/src/config/iisnode_schema.xml
+++ b/src/config/iisnode_schema.xml
@@ -30,6 +30,7 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="node_env" type="string" expanded="true" defaultValue="%node_env%"/>
     <attribute name="asyncCompletionThreadCount" type="uint" defaultValue="0"/>
     <attribute name="nodeProcessCountPerApplication" type="uint" defaultValue="1"/>
+    <attribute name="nodeProcessStickySessions" type="bool" defaultValue="false"/>
     <attribute name="nodeProcessCommandLine" type="string" expanded="true" defaultValue="node.exe"/>
     <attribute name="interceptor" type="string" expanded="true" defaultValue="&quot;%programfiles%\iisnode\interceptor.js&quot;" />
     <attribute name="maxConcurrentRequestsPerProcess" type="uint" allowInfitnite="true" defaultValue="1024"/>

--- a/src/config/iisnode_schema_x64.xml
+++ b/src/config/iisnode_schema_x64.xml
@@ -30,6 +30,7 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="node_env" type="string" expanded="true" defaultValue="%node_env%"/>
     <attribute name="asyncCompletionThreadCount" type="uint" defaultValue="0"/>
     <attribute name="nodeProcessCountPerApplication" type="uint" defaultValue="1"/>
+    <attribute name="nodeProcessStickySessions" type="bool" defaultValue="false"/>
     <attribute name="nodeProcessCommandLine" type="string" expanded="true" defaultValue="node.exe"/>
     <attribute name="interceptor" type="string" expanded="true" defaultValue="&quot;%programfiles%\iisnode\interceptor.js&quot;" />
     <attribute name="maxConcurrentRequestsPerProcess" type="uint" allowInfitnite="true" defaultValue="1024"/>

--- a/src/iisnode/cmoduleconfiguration.cpp
+++ b/src/iisnode/cmoduleconfiguration.cpp
@@ -752,6 +752,10 @@ HRESULT CModuleConfiguration::ApplyConfigOverrideKeyValue(IHttpContext* context,
     {
         CheckError(GetDWORD(valueStart, &config->maxConcurrentRequestsPerProcess));
     }
+	else if (0 == strcmpi(keyStart, "nodeProcessStickySessions"))
+    {
+        CheckError(GetDWORD(valueStart, &config->nodeProcessStickySessions));
+    }
     else if (0 == strcmpi(keyStart, "maxNamedPipeConnectionRetry"))
     {
         CheckError(GetDWORD(valueStart, &config->maxNamedPipeConnectionRetry));
@@ -1198,6 +1202,7 @@ HRESULT CModuleConfiguration::GetConfig(IHttpContext* context, CModuleConfigurat
         CheckError(GetConfigSection(context, &section));		
         CheckError(GetDWORD(section, L"asyncCompletionThreadCount", &c->asyncCompletionThreadCount));
         CheckError(GetDWORD(section, L"nodeProcessCountPerApplication", &c->nodeProcessCountPerApplication));
+        CheckError(GetDWORD(section, L"nodeProcessStickySessions", &c->nodeProcessStickySessions));
         CheckError(GetDWORD(section, L"maxConcurrentRequestsPerProcess", &c->maxConcurrentRequestsPerProcess));
         CheckError(GetDWORD(section, L"maxNamedPipeConnectionRetry", &c->maxNamedPipeConnectionRetry));
         CheckError(GetDWORD(section, L"namedPipeConnectionRetryDelay", &c->namedPipeConnectionRetryDelay));
@@ -1298,6 +1303,11 @@ DWORD CModuleConfiguration::GetAsyncCompletionThreadCount(IHttpContext* ctx)
 DWORD CModuleConfiguration::GetNodeProcessCountPerApplication(IHttpContext* ctx)
 {
     GETCONFIG(nodeProcessCountPerApplication)
+}
+
+DWORD CModuleConfiguration::GetProcessStickySessions(IHttpContext* ctx)
+{
+    GETCONFIG(nodeProcessStickySessions)
 }
 
 LPWSTR CModuleConfiguration::GetNodeProcessCommandLine(IHttpContext* ctx)

--- a/src/iisnode/cmoduleconfiguration.h
+++ b/src/iisnode/cmoduleconfiguration.h
@@ -9,6 +9,7 @@ private:
 
     DWORD asyncCompletionThreadCount;
     DWORD nodeProcessCountPerApplication;
+    DWORD nodeProcessStickySessions;
     LPWSTR nodeProcessCommandLine;
     LPWSTR interceptor;
     DWORD maxConcurrentRequestsPerProcess;
@@ -94,6 +95,7 @@ public:
     static DWORD GetIdlePageOutTimePeriod(IHttpContext* ctx);
     static DWORD GetAsyncCompletionThreadCount(IHttpContext* ctx); 
     static DWORD GetNodeProcessCountPerApplication(IHttpContext* ctx);
+    static DWORD GetProcessStickySessions(IHttpContext* ctx);
     static LPWSTR GetNodeProcessCommandLine(IHttpContext* ctx); 
     static LPWSTR GetInterceptor(IHttpContext* ctx); 
     static DWORD GetMaxConcurrentRequestsPerProcess(IHttpContext* ctx);

--- a/src/iisnode/cnodeprocessmanager.cpp
+++ b/src/iisnode/cnodeprocessmanager.cpp
@@ -126,6 +126,7 @@ int CNodeProcessManager::ExtractStickySessionsProcess( PCSTR pszCookie )
 		pEnd = strstr(pStart, pszNext);
 		if(!pEnd) 
 		{
+			pEnd = pStart;
 			while (pEnd) /* Works because end-of-string and FALSE are identical. */
 			{
 				pEnd++;

--- a/src/iisnode/cnodeprocessmanager.h
+++ b/src/iisnode/cnodeprocessmanager.h
@@ -22,6 +22,7 @@ private:
 	CNodeApplication* application;
 	CNodeProcess** processes;
 	DWORD processCount;
+	BOOL stickySessions;
 	unsigned int currentProcess;
 	SRWLOCK srwlock;
 	DWORD gracefulShutdownTimeout;
@@ -51,6 +52,8 @@ public:
 	long DecRef();
 	DWORD GetActiveRequestCount();
 	DWORD GetProcessCount();
+	DWORD GetProcessStickySessions();
+	int ExtractStickySessionsProcess( PCSTR pszCookie );
 };
 
 #endif

--- a/src/samples/configuration/iisnode.yml
+++ b/src/samples/configuration/iisnode.yml
@@ -23,6 +23,11 @@ node_env:
 
 nodeProcessCountPerApplication: 1
 
+# nodeProcessStickySessions - boolean indicating whether all requests from one client should be routed
+# the same node.exe process by adding and evaluting a cookie carrying a hint for the target process
+
+nodeProcessStickySessions: false
+
 # maxConcurrentRequestsPerProcess - maximum number of reqeusts one node process can
 # handle at a time
 

--- a/src/samples/configuration/readme.htm
+++ b/src/samples/configuration/readme.htm
@@ -62,6 +62,9 @@ console.log('Application started at location ' + process.env.PORT);</pre>
     * nodeProcessCountPerApplication - number of node.exe processes that IIS will start per application;
       setting this value to 0 results in creating one node.exe process per each processor on the machine
       
+    * nodeProcessStickySessions - boolean indicating whether all requests from one client should be routed
+      the same node.exe process by adding and evaluting a cookie carrying a hint for the target process
+
     * maxConcurrentRequestsPerProcess - maximum number of reqeusts one node process can 
       handle at a time
       
@@ -216,6 +219,11 @@ node_env:
 # setting this value to 0 results in creating one node.exe process per each processor on the machine
 
 nodeProcessCountPerApplication: 1
+
+# nodeProcessStickySessions - boolean indicating whether all requests from one cliet should always
+# be routed to the same node.exe process by adding and evaluting a sticky session cookie
+
+nodeProcessStickySessions: false
 
 # maxConcurrentRequestsPerProcess - maximum number of reqeusts one node process can
 # handle at a time

--- a/src/samples/configuration/web.config
+++ b/src/samples/configuration/web.config
@@ -27,6 +27,9 @@
     * nodeProcessCountPerApplication - number of node.exe processes that IIS will start per application;
       setting this value to 0 results in creating one node.exe process per each processor on the machine
       
+    * nodeProcessStickySessions - boolean indicating whether all requests from one cliet should be routed
+      the same node.exe process by adding and evaluting a cookie carrying a hint for the target process
+
     * maxConcurrentRequestsPerProcess - maximum number of reqeusts one node process can 
       handle at a time
       

--- a/src/samples/configuration/web.config
+++ b/src/samples/configuration/web.config
@@ -27,7 +27,7 @@
     * nodeProcessCountPerApplication - number of node.exe processes that IIS will start per application;
       setting this value to 0 results in creating one node.exe process per each processor on the machine
       
-    * nodeProcessStickySessions - boolean indicating whether all requests from one cliet should be routed
+    * nodeProcessStickySessions - boolean indicating whether all requests from one client should be routed
       the same node.exe process by adding and evaluting a cookie carrying a hint for the target process
 
     * maxConcurrentRequestsPerProcess - maximum number of reqeusts one node process can 


### PR DESCRIPTION
Setting nodeProcessStickySessions to true will set a cookie on a
client's first request, carrying a hint for the target node.exe process.
Each subsequent request will then be routed to the process mentioned in
the cookie.

Pull-Request for #381 
