### PR TITLE
Remove "Branches" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 Hosting node.js applications in IIS on Windows
 ===
 
-**Branches**
-
-- master: stable version.
-- iisnode-dev: development branch.
-
 **Why would I want to do it?**
 
 [Benefits](https://github.com/tjanczuk/iisnode/wiki)


### PR DESCRIPTION
Looks like `iisnode-dev` is gone and there's only a `master` branch now...