### PR TITLE
Switch to checking if the conenction header contains 'upgrade' rather than equals 'upgrade'

### DIFF
--- a/src/iisnode/cprotocolbridge.cpp
+++ b/src/iisnode/cprotocolbridge.cpp
@@ -723,7 +723,7 @@ void CProtocolBridge::SendHttpRequestHeaders(CNodeHttpStoredContext* context)
 
     pszConnectionHeader = request->GetHeader(HttpHeaderConnection);
     if( pszConnectionHeader == NULL || 
-        (pszConnectionHeader != NULL && stricmp(pszConnectionHeader, "upgrade") != 0))
+        (pszConnectionHeader != NULL && strstr(pszConnectionHeader, "upgrade") == NULL))
     {
         CheckError(request->SetHeader(HttpHeaderConnection, "keep-alive", 10, TRUE));
     }


### PR DESCRIPTION
A potential solution to the issue firefox has where it sends both 'keep-alive' and 'upgrade' in the connection header (see https://github.com/tjanczuk/iisnode/issues/497)

I don't have much experience with C++ or the project so if there's any other changes required or tests that need to be updated/created I'm happy to look into that with some direction