### PR TITLE
Update Express sample to remove deprecated method

### DIFF
--- a/src/samples/express/hello.js
+++ b/src/samples/express/hello.js
@@ -1,6 +1,6 @@
 var express = require('express');
 
-var app = express.createServer();
+var app = express();
 
 app.get('/node/express/myapp/foo', function (req, res) {
     res.send('Hello from foo! [express sample]');


### PR DESCRIPTION
Update sample to use express() since express.createServer() is deprecated.