### PR TITLE
Fix unclickable triangles in node-inspector

### DIFF
--- a/src/iisnode/node-inspector-0.7.3/node_modules/node-inspector/front-end/treeoutline.js
+++ b/src/iisnode/node-inspector-0.7.3/node_modules/node-inspector/front-end/treeoutline.js
@@ -940,8 +940,8 @@ TreeElement.prototype.traversePreviousTreeElement = function(skipUnrevealed, don
 TreeElement.prototype.isEventWithinDisclosureTriangle = function(event)
 {
     // FIXME: We should not use getComputedStyle(). For that we need to get rid of using ::before for disclosure triangle. (http://webk.it/74446) 
-    var paddingLeftValue = window.getComputedStyle(this._listItemNode).getPropertyCSSValue("padding-left");
-    var computedLeftPadding = paddingLeftValue ? paddingLeftValue.getFloatValue(CSSPrimitiveValue.CSS_PX) : 0;
+    var paddingLeftValue = window.getComputedStyle(this._listItemNode).getPropertyValue("padding-left");
+    var computedLeftPadding = paddingLeftValue ? paddingLeftValue : 0;
     var left = this._listItemNode.totalOffsetLeft() + computedLeftPadding;
     return event.pageX >= left && event.pageX <= left + this.arrowToggleWidth && this.hasChildren;
 }


### PR DESCRIPTION
The version of node-inspector being used is very old, and contains some
calls which no longer work in Chrome. node-inspector itself fixed this
bug in December of 2014, and it's frustrating enough for me that I
ported the changes into iisnode's version of the debugger.

Original fix: https://github.com/node-inspector/node-inspector/pull/479