### PR TITLE
Feature addition: skipIISCustomErrors

### DIFF
--- a/src/config/iisnode_dev_x64.xml
+++ b/src/config/iisnode_dev_x64.xml
@@ -60,5 +60,6 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="configOverrides" type="string" expanded="true" defaultValue="iisnode.yml"/>
     <attribute name="recycleSignalEnabled" type="bool" defaultValue="false"/>
     <attribute name="idlePageOutTimePeriod" type="uint" defaultValue="0" /> <!-- disabled with default value 0 -->
+    <attribute name="skipIISCustomErrors" type="bool" defaultValue="false" />
   </sectionSchema>
 </configSchema>

--- a/src/config/iisnode_dev_x86_on_x64.xml
+++ b/src/config/iisnode_dev_x86_on_x64.xml
@@ -60,5 +60,6 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="configOverrides" type="string" expanded="true" defaultValue="iisnode.yml"/>
     <attribute name="recycleSignalEnabled" type="bool" defaultValue="false"/>
     <attribute name="idlePageOutTimePeriod" type="uint" defaultValue="0" /> <!-- disabled with default value 0 -->
+    <attribute name="skipIISCustomErrors" type="bool" defaultValue="false" />
   </sectionSchema>
 </configSchema>

--- a/src/config/iisnode_dev_x86_on_x86.xml
+++ b/src/config/iisnode_dev_x86_on_x86.xml
@@ -60,5 +60,6 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="configOverrides" type="string" expanded="true" defaultValue="iisnode.yml"/>
     <attribute name="recycleSignalEnabled" type="bool" defaultValue="false"/>
     <attribute name="idlePageOutTimePeriod" type="uint" defaultValue="0" /> <!-- disabled with default value 0 -->
+    <attribute name="skipIISCustomErrors" type="bool" defaultValue="false" />
   </sectionSchema>
 </configSchema>

--- a/src/config/iisnode_express_schema.xml
+++ b/src/config/iisnode_express_schema.xml
@@ -60,5 +60,6 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="configOverrides" type="string" expanded="true" defaultValue="iisnode.yml"/>
     <attribute name="recycleSignalEnabled" type="bool" defaultValue="false"/>
     <attribute name="idlePageOutTimePeriod" type="uint" defaultValue="0" /> <!-- disabled with default value 0 -->
+    <attribute name="skipIISCustomErrors" type="bool" defaultValue="false" />
   </sectionSchema>
 </configSchema>

--- a/src/config/iisnode_express_schema_x64.xml
+++ b/src/config/iisnode_express_schema_x64.xml
@@ -60,5 +60,6 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="configOverrides" type="string" expanded="true" defaultValue="iisnode.yml"/>
     <attribute name="recycleSignalEnabled" type="bool" defaultValue="false"/>
     <attribute name="idlePageOutTimePeriod" type="uint" defaultValue="0" /> <!-- disabled with default value 0 -->
+    <attribute name="skipIISCustomErrors" type="bool" defaultValue="false" />
   </sectionSchema>
 </configSchema>

--- a/src/config/iisnode_schema.xml
+++ b/src/config/iisnode_schema.xml
@@ -60,5 +60,6 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="configOverrides" type="string" expanded="true" defaultValue="iisnode.yml"/>
     <attribute name="recycleSignalEnabled" type="bool" defaultValue="false"/>
     <attribute name="idlePageOutTimePeriod" type="uint" defaultValue="0" /> <!-- disabled with default value 0 -->
+    <attribute name="skipIISCustomErrors" type="bool" defaultValue="false" />
   </sectionSchema>
 </configSchema>

--- a/src/config/iisnode_schema_x64.xml
+++ b/src/config/iisnode_schema_x64.xml
@@ -60,5 +60,6 @@ Details at http://learn.iis.net/page.aspx/241/configuration-extensibility/
     <attribute name="configOverrides" type="string" expanded="true" defaultValue="iisnode.yml"/>
     <attribute name="recycleSignalEnabled" type="bool" defaultValue="false"/>
     <attribute name="idlePageOutTimePeriod" type="uint" defaultValue="0" /> <!-- disabled with default value 0 -->
+    <attribute name="skipIISCustomErrors" type="bool" defaultValue="false"/>"
   </sectionSchema>
 </configSchema>

--- a/src/iisnode/chttpprotocol.cpp
+++ b/src/iisnode/chttpprotocol.cpp
@@ -364,7 +364,8 @@ HRESULT CHttpProtocol::ParseResponseStatusLine(CNodeHttpStoredContext* context)
 	data[newOffset] = 0; // zero-terminate the reason phrase to reuse it without copying
 
 	IHttpResponse* response = context->GetHttpContext()->GetResponse();
-	response->SetStatus(statusCode, data + offset, subStatusCode);
+	
+	response->SetStatus(statusCode, data + offset, subStatusCode, S_OK, NULL, TRUE);
 	
 	// adjust buffers
 

--- a/src/iisnode/chttpprotocol.cpp
+++ b/src/iisnode/chttpprotocol.cpp
@@ -367,6 +367,11 @@ HRESULT CHttpProtocol::ParseResponseStatusLine(CNodeHttpStoredContext* context)
 
 	if (CModuleConfiguration::GetSkipIISCustomErrors(context->GetHttpContext()))
 	{
+		// set fTrySkipCustomErrors so that error responses sent back from the node app through iisnode
+		// are passed through to the client instead of being intercepted by IIS when httpErrors existingResponse="Auto"
+		// this allows a mixed solution where custom error pages can be provided via IIS for errors that occur outside
+		// of iisnode's purview, while also allowing usually-more-helpful error responses from the node application
+		// to be passed through to the client rather than being intercepted by IIS.
 		response->SetStatus(statusCode, data + offset, subStatusCode, S_OK, NULL, TRUE);
 	}
 	else

--- a/src/iisnode/chttpprotocol.cpp
+++ b/src/iisnode/chttpprotocol.cpp
@@ -364,8 +364,15 @@ HRESULT CHttpProtocol::ParseResponseStatusLine(CNodeHttpStoredContext* context)
 	data[newOffset] = 0; // zero-terminate the reason phrase to reuse it without copying
 
 	IHttpResponse* response = context->GetHttpContext()->GetResponse();
-	
-	response->SetStatus(statusCode, data + offset, subStatusCode, S_OK, NULL, TRUE);
+
+	if (CModuleConfiguration::GetSkipIISCustomErrors(context->GetHttpContext()))
+	{
+		response->SetStatus(statusCode, data + offset, subStatusCode, S_OK, NULL, TRUE);
+	}
+	else
+	{
+		response->SetStatus(statusCode, data + offset, subStatusCode);
+	}
 	
 	// adjust buffers
 

--- a/src/iisnode/cmoduleconfiguration.cpp
+++ b/src/iisnode/cmoduleconfiguration.cpp
@@ -888,10 +888,10 @@ HRESULT CModuleConfiguration::ApplyConfigOverrideKeyValue(IHttpContext* context,
     {
         CheckError(GetDWORD(valueStart, &config->idlePageOutTimePeriod));
     }
-	else if(0 == stricmp(keyStart, "skipIISCustomErrors"))
-	{
-		CheckError(GetBOOL(valueStart, &config->skipIISCustomErrors));
-	}
+    else if(0 == stricmp(keyStart, "skipIISCustomErrors"))
+    {
+        CheckError(GetBOOL(valueStart, &config->skipIISCustomErrors));
+    }
 
     return S_OK;
 Error:
@@ -1251,7 +1251,7 @@ HRESULT CModuleConfiguration::GetConfig(IHttpContext* context, CModuleConfigurat
         CheckError(GetString(section, L"nodeProcessCommandLine", &c->nodeProcessCommandLine));
         CheckError(GetString(section, L"interceptor", &c->interceptor));
         CheckError(GetDWORD(section, L"idlePageOutTimePeriod", &c->idlePageOutTimePeriod));
-		CheckError(GetBOOL(section, L"skipIISCustomErrors", &c->skipIISCustomErrors, FALSE));
+        CheckError(GetBOOL(section, L"skipIISCustomErrors", &c->skipIISCustomErrors, FALSE));
 
         // debuggerPathSegment
 
@@ -1495,7 +1495,7 @@ LPWSTR CModuleConfiguration::GetConfigOverrides(IHttpContext* ctx)
 
 BOOL CModuleConfiguration::GetSkipIISCustomErrors(IHttpContext* ctx)
 {
-	GETCONFIG(skipIISCustomErrors)
+    GETCONFIG(skipIISCustomErrors)
 }
 
 HRESULT CModuleConfiguration::GenerateDebuggerConfig(IHttpContext* context, CModuleConfiguration *config)

--- a/src/iisnode/cmoduleconfiguration.cpp
+++ b/src/iisnode/cmoduleconfiguration.cpp
@@ -888,6 +888,10 @@ HRESULT CModuleConfiguration::ApplyConfigOverrideKeyValue(IHttpContext* context,
     {
         CheckError(GetDWORD(valueStart, &config->idlePageOutTimePeriod));
     }
+	else if(0 == stricmp(keyStart, "skipIISCustomErrors"))
+	{
+		CheckError(GetBOOL(valueStart, &config->skipIISCustomErrors));
+	}
 
     return S_OK;
 Error:
@@ -1247,6 +1251,7 @@ HRESULT CModuleConfiguration::GetConfig(IHttpContext* context, CModuleConfigurat
         CheckError(GetString(section, L"nodeProcessCommandLine", &c->nodeProcessCommandLine));
         CheckError(GetString(section, L"interceptor", &c->interceptor));
         CheckError(GetDWORD(section, L"idlePageOutTimePeriod", &c->idlePageOutTimePeriod));
+		CheckError(GetBOOL(section, L"skipIISCustomErrors", &c->skipIISCustomErrors, FALSE));
 
         // debuggerPathSegment
 
@@ -1486,6 +1491,11 @@ BOOL CModuleConfiguration::GetEnableXFF(IHttpContext* ctx)
 LPWSTR CModuleConfiguration::GetConfigOverrides(IHttpContext* ctx)
 {
     GETCONFIG(configOverrides)
+}
+
+BOOL CModuleConfiguration::GetSkipIISCustomErrors(IHttpContext* ctx)
+{
+	GETCONFIG(skipIISCustomErrors)
 }
 
 HRESULT CModuleConfiguration::GenerateDebuggerConfig(IHttpContext* context, CModuleConfiguration *config)

--- a/src/iisnode/cmoduleconfiguration.h
+++ b/src/iisnode/cmoduleconfiguration.h
@@ -52,7 +52,7 @@ private:
     static BOOL invalid;
     SRWLOCK srwlock;
     LPWSTR configOverrides;
-	BOOL skipIISCustomErrors;
+    BOOL skipIISCustomErrors;
 
     static IHttpServer* server;
     static HTTP_MODULE_ID moduleId;
@@ -130,7 +130,7 @@ public:
     static BOOL GetEnableXFF(IHttpContext* ctx);
     static HRESULT GetPromoteServerVars(IHttpContext* ctx, char*** vars, int* count);
     static LPWSTR GetConfigOverrides(IHttpContext* ctx);
-	static BOOL GetSkipIISCustomErrors(IHttpContext* ctx);
+    static BOOL GetSkipIISCustomErrors(IHttpContext* ctx);
 
     static HRESULT CreateNodeEnvironment(IHttpContext* ctx, DWORD debugPort, PCH namedPipe, PCH signalPipeName, PCH* env);
 

--- a/src/iisnode/cmoduleconfiguration.h
+++ b/src/iisnode/cmoduleconfiguration.h
@@ -52,6 +52,7 @@ private:
     static BOOL invalid;
     SRWLOCK srwlock;
     LPWSTR configOverrides;
+	BOOL skipIISCustomErrors;
 
     static IHttpServer* server;
     static HTTP_MODULE_ID moduleId;
@@ -129,6 +130,7 @@ public:
     static BOOL GetEnableXFF(IHttpContext* ctx);
     static HRESULT GetPromoteServerVars(IHttpContext* ctx, char*** vars, int* count);
     static LPWSTR GetConfigOverrides(IHttpContext* ctx);
+	static BOOL GetSkipIISCustomErrors(IHttpContext* ctx);
 
     static HRESULT CreateNodeEnvironment(IHttpContext* ctx, DWORD debugPort, PCH namedPipe, PCH signalPipeName, PCH* env);
 

--- a/src/iisnode/cnodehttpmodule.cpp
+++ b/src/iisnode/cnodehttpmodule.cpp
@@ -173,7 +173,7 @@ REQUEST_NOTIFICATION_STATUS CNodeHttpModule::OnExecuteRequestHandler(
             if (FAILED(hr))
             {
                 // Set the HTTP status.
-                pHttpResponse->SetStatus(500,"Server Error",0,hr);
+                pHttpResponse->SetStatus(500,"Server Error",0,hr,NULL,TRUE);
             }
 
             // End additional processing.

--- a/src/iisnode/cnodehttpmodule.cpp
+++ b/src/iisnode/cnodehttpmodule.cpp
@@ -173,7 +173,7 @@ REQUEST_NOTIFICATION_STATUS CNodeHttpModule::OnExecuteRequestHandler(
             if (FAILED(hr))
             {
                 // Set the HTTP status.
-                pHttpResponse->SetStatus(500,"Server Error",0,hr,NULL,TRUE);
+                pHttpResponse->SetStatus(500,"Server Error",0,hr);
             }
 
             // End additional processing.

--- a/src/iisnode/cprotocolbridge.cpp
+++ b/src/iisnode/cprotocolbridge.cpp
@@ -459,7 +459,15 @@ void CProtocolBridge::SendEmptyResponse(IHttpContext* httpCtx, USHORT status, US
     if (!httpCtx->GetResponseHeadersSent())
     {
         httpCtx->GetResponse()->Clear();
-        httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult, NULL, TRUE);
+		if (CModuleConfiguration::GetSkipIISCustomErrors(httpCtx))
+		{
+			httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult, NULL, TRUE);
+		}
+		else
+		{
+			httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult);
+		}
+       
         if (disableCache)
         {
             httpCtx->GetResponse()->SetHeader(HttpHeaderCacheControl, "no-cache", 8, TRUE);

--- a/src/iisnode/cprotocolbridge.cpp
+++ b/src/iisnode/cprotocolbridge.cpp
@@ -459,14 +459,10 @@ void CProtocolBridge::SendEmptyResponse(IHttpContext* httpCtx, USHORT status, US
     if (!httpCtx->GetResponseHeadersSent())
     {
         httpCtx->GetResponse()->Clear();
-		if (CModuleConfiguration::GetSkipIISCustomErrors(httpCtx))
-		{
-			httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult, NULL, TRUE);
-		}
-		else
-		{
-			httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult);
-		}
+
+        // Internal iisnode errors should probably not set fTrySkipCustomErrors since these are just empty status responses.
+        // Let IIS capture and replace these responses with more detailed messages depending on the custom error mode.
+		httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult);
        
         if (disableCache)
         {

--- a/src/iisnode/cprotocolbridge.cpp
+++ b/src/iisnode/cprotocolbridge.cpp
@@ -462,7 +462,7 @@ void CProtocolBridge::SendEmptyResponse(IHttpContext* httpCtx, USHORT status, US
 
         // Internal iisnode errors should probably not set fTrySkipCustomErrors since these are just empty status responses.
         // Let IIS capture and replace these responses with more detailed messages depending on the custom error mode.
-		httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult);
+        httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult);
        
         if (disableCache)
         {

--- a/src/iisnode/cprotocolbridge.cpp
+++ b/src/iisnode/cprotocolbridge.cpp
@@ -459,7 +459,7 @@ void CProtocolBridge::SendEmptyResponse(IHttpContext* httpCtx, USHORT status, US
     if (!httpCtx->GetResponseHeadersSent())
     {
         httpCtx->GetResponse()->Clear();
-        httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult);
+        httpCtx->GetResponse()->SetStatus(status, reason, subStatus, hresult, NULL, TRUE);
         if (disableCache)
         {
             httpCtx->GetResponse()->SetHeader(HttpHeaderCacheControl, "no-cache", 8, TRUE);

--- a/src/samples/configuration/iisnode.yml
+++ b/src/samples/configuration/iisnode.yml
@@ -142,3 +142,6 @@ enableXFF: false
 # http://msdn.microsoft.com/en-us/library/ms524602(v=vs.90).aspx; for example "AUTH_USER,AUTH_TYPE"
 
 promoteServerVars:     
+
+# skipIISCustomErrors - controls whether iisnode will try to skip IIS <httpErrors> custom error handling when existingResponse="Auto"
+skipIISCustomErrors: false

--- a/src/samples/configuration/readme.htm
+++ b/src/samples/configuration/readme.htm
@@ -145,6 +145,8 @@ console.log('Application started at location ' + process.env.PORT);</pre>
             maxRequestBufferSize: 8192 # increasing from the default
             # maxConcurrentRequestsPerProcess: 512 - commented out setting
 
+    * skipIISCustomErrors - controls whether iisnode will try to skip IIS &gt;httpErrors&lt; custom error handling when existingResponse="Auto"
+
     --&gt;
     
     &lt;iisnode      
@@ -175,6 +177,7 @@ console.log('Application started at location ' + process.env.PORT);</pre>
       enableXFF="false"
       promoteServerVars=""
       configOverrides="node.conf"
+      skipIISCustomErrors="false"
      /&gt;
 
     &lt;!--     
@@ -335,6 +338,10 @@ enableXFF: false
 # HTTP request headers; for a list of IIS server variables available see
 # http://msdn.microsoft.com/en-us/library/ms524602(v=vs.90).aspx; for example "AUTH_USER,AUTH_TYPE"
 
-promoteServerVars:</pre>
+promoteServerVars:
+
+# skipIISCustomErrors - controls whether iisnode will try to skip IIS &gt;httpErrors&lt; custom error handling when existingResponse="Auto"
+skipIISCustomErrors: false
+</pre>
 </body>
 </html>

--- a/src/samples/configuration/web.config
+++ b/src/samples/configuration/web.config
@@ -109,6 +109,8 @@
             nodeProcessCountPerApplication: 2
             maxRequestBufferSize: 8192 # increasing from the default
             # maxConcurrentRequestsPerProcess: 512 - commented out setting
+            
+    * skipIISCustomErrors - controls whether iisnode will try to skip IIS <httpErrors> custom error handling when existingResponse="Auto"
       
     -->
 
@@ -140,6 +142,7 @@
       enableXFF="false"
       promoteServerVars=""
       configOverrides="iisnode.yml"
+      skipIISCustomErrors="false"
      />
 
     <!--     

--- a/test/functional/tests/144_skip_iis_custom_errors.js
+++ b/test/functional/tests/144_skip_iis_custom_errors.js
@@ -1,0 +1,18 @@
+var iisnodeassert = require("iisnodeassert");
+
+iisnodeassert.sequence([
+    // when skipIISCustomErrors="true", error responses returned by the node application should pass through to the client
+    // when skipIISCustomErrors="false", IIS can intercept error responses from the node application with custom error handling based on the error code
+    // this option only comes into play when httpErrors existingResponse="Auto".
+    // existingResponse="PassThrough" and existingResponse="Replace" will always pass error messages from the node app through to the client or replace them, respectively
+    iisnodeassert.get(10000, "/143_skip_iis_custom_errors/on/create_error.js", 400, 'App created error. Gets replaced by IIS Custom error if skipIISCustomErrors="false"'),
+    iisnodeassert.get(10000, "/143_skip_iis_custom_errors/off/create_error.js", 400, 'Bad Request'),
+
+    // iisnode skipIISCustomErrors option should not affect custom error routing for errors outside of iisnode's purview
+    iisnodeassert.get(10000, "/143_skip_iis_custom_errors/on/access_denied.js", 401, 'IIS Custom Error page still gets served for non iisnode error responses'),
+    iisnodeassert.get(10000, "/143_skip_iis_custom_errors/off/access_denied.js", 401, 'IIS Custom Error page still gets served for non iisnode error responses'),
+
+    // internal iisnode errors should still get extra handling by IIS depending on error mode
+    iisnodeassert.get(10000, "/143_skip_iis_custom_errors/on/malformed.js", 500, 'The page cannot be displayed because an internal server error has occurred.'),
+    iisnodeassert.get(10000, "/143_skip_iis_custom_errors/off/malformed.js", 500, 'The page cannot be displayed because an internal server error has occurred.'),    
+]);

--- a/test/functional/www/143_skip_iis_custom_errors/error.html
+++ b/test/functional/www/143_skip_iis_custom_errors/error.html
@@ -1,0 +1,1 @@
+IIS Custom Error page still gets served for non iisnode error responses

--- a/test/functional/www/143_skip_iis_custom_errors/off/access_denied.js
+++ b/test/functional/www/143_skip_iis_custom_errors/off/access_denied.js
@@ -1,0 +1,6 @@
+var http = require('http');
+
+http.createServer(function (req, res) {
+    res.writeHead(200, {'Content-Type': 'text/html'});
+    res.end('Hello, world!');
+}).listen(process.env.PORT);  

--- a/test/functional/www/143_skip_iis_custom_errors/off/create_error.js
+++ b/test/functional/www/143_skip_iis_custom_errors/off/create_error.js
@@ -1,0 +1,6 @@
+var http = require('http');
+
+http.createServer(function (req, res) {
+    res.writeHead(400, {'Content-Type': 'text/html'});
+    res.end('Created error');
+}).listen(process.env.PORT);  

--- a/test/functional/www/143_skip_iis_custom_errors/off/malformed.js
+++ b/test/functional/www/143_skip_iis_custom_errors/off/malformed.js
@@ -1,0 +1,1 @@
+invalid js file

--- a/test/functional/www/143_skip_iis_custom_errors/off/web.config
+++ b/test/functional/www/143_skip_iis_custom_errors/off/web.config
@@ -1,0 +1,5 @@
+<configuration>
+  <system.webServer>
+    <iisnode skipIISCustomErrors="false" />
+  </system.webServer>
+</configuration>

--- a/test/functional/www/143_skip_iis_custom_errors/on/access_denied.js
+++ b/test/functional/www/143_skip_iis_custom_errors/on/access_denied.js
@@ -1,0 +1,6 @@
+var http = require('http');
+
+http.createServer(function (req, res) {
+    res.writeHead(200, {'Content-Type': 'text/html'});
+    res.end('Hello, world!');
+}).listen(process.env.PORT);  

--- a/test/functional/www/143_skip_iis_custom_errors/on/create_error.js
+++ b/test/functional/www/143_skip_iis_custom_errors/on/create_error.js
@@ -1,0 +1,6 @@
+var http = require('http');
+
+http.createServer(function (req, res) {
+    res.writeHead(400, {'Content-Type': 'text/html'});
+    res.end('App created error. Gets replaced by IIS Custom error if skipIISCustomErrors="false"');
+}).listen(process.env.PORT);  

--- a/test/functional/www/143_skip_iis_custom_errors/on/malformed.js
+++ b/test/functional/www/143_skip_iis_custom_errors/on/malformed.js
@@ -1,0 +1,1 @@
+invalid js file

--- a/test/functional/www/143_skip_iis_custom_errors/on/web.config
+++ b/test/functional/www/143_skip_iis_custom_errors/on/web.config
@@ -1,0 +1,5 @@
+<configuration>
+  <system.webServer>
+    <iisnode skipIISCustomErrors="true" />
+  </system.webServer>
+</configuration>

--- a/test/functional/www/143_skip_iis_custom_errors/web.config
+++ b/test/functional/www/143_skip_iis_custom_errors/web.config
@@ -1,0 +1,60 @@
+<configuration>
+  <system.webServer>
+    <!-- 
+    errorMode="Custom" to prevent IIS from helpfully serving a more detailed error .aspx page when run locally
+    Default error mode is DetailedLocalOnly, which serves custom errors to remote users and more detailed error pages
+    to local users.
+    -->
+    <httpErrors existingResponse="Auto" errorMode="Custom">
+      <clear />
+      <remove statusCode="401" />
+      <error statusCode="401" path="error.html" responseMode="File" />
+    </httpErrors>
+    <handlers>
+      <add name="iisnode" path="*/*.js" verb="*" modules="iisnode" />
+    </handlers>
+    <iisnode devErrorsEnabled="false" />
+  </system.webServer>
+
+  <!--
+   Cause requests to hello.js to fail authentication before hitting iisnode. 
+   In this scenario, we may want to re-route to a custom error page via IIS
+   since we won't be able to handle the request in the node application.
+   -->
+  <location path="off/access_denied.js">
+    <system.webServer>
+      <security>
+        <authorization>
+          <clear />
+          <add accessType="Deny" users="*" />
+        </authorization>
+      </security>
+    </system.webServer>
+  </location>
+  <location path="on/access_denied.js">
+    <system.webServer>
+      <security>
+        <authorization>
+          <clear />
+          <add accessType="Deny" users="*" />
+        </authorization>
+      </security>
+    </system.webServer>
+  </location>
+
+  <!-- 
+  Need to allow users access to error.html. 
+  NOTE: Seprately, you will need to give IUSR account read access to custom error page so that IIS can access and serve the file.
+  -->
+  <location path="error.html">
+    <system.webServer>
+      <security>
+        <authorization>
+          <clear />
+          <add accessType="Allow" users="*" />
+        </authorization>
+      </security>
+    </system.webServer>
+  </location>
+
+</configuration>


### PR DESCRIPTION
 (see #446 and #476)

This feature will allow a mixed solution to error handling with IIS and iisnode rather than relying `<httpErrors existingResponse="PassThrough" />`
to work around IIS trying to replace error responses from the node application with custom friendly error pages.

The default mechanism `existingResponse="Auto"` allows for the following behavior:

> 1. If the IHttpResponse::SetStatus method was called by using the fTrySkipCustomErrors flag, the existing response is passed through, and no detailed or custom error is shown.
> 2. If the ErrorMode property is set to Custom, the response is replaced.
> 3. If ErrorMode is set to Detailed and there is an existing response, the response is passed through.
> 4. If ErrorMode is set to Detailed and there is no existing response, the response is replaced with a detailed error.

This feature would allow an opt-in into option 1, where responses returned from the node application through iisnode would call `IHttpResponse::SetStatus` with the `fTrySkipCustomErrors` flag set if iisnode is configured with `skipIISCustomErrors="true"`. Empty error responses resulting from internal iisnode errors will not be affected by this, so that those errors can be handled by IIS. This is only really a factor if `devErrorsEnabled="false"`.

This sort of work flow is useful because usually the node application should be gracefully handling and creating friendly/helpful error responses to be passed to the client. Sometimes, `existingResponse="PassThrough"` is acceptable for this if you never need to do any custom error handling outside of iisnode. However, if you happened to need this, then you are stuck. For example, if you would like to route users of your site to a friendly error page directing them to request the necessary security group accesses they need if they do not pass authentication, then you need to implement custom error routing in the `<httpErrors>` section of your web config since this sort of error is not under iisnode's purview. But anything other than `existingResponse="PassThrough"` will interfere with your existing node application error messages.

With this feature, you can set `skipIISCustomErrors="true"` in iisnode's configuration so that any responses sent back through iisnode from the node application will be passed with the TrySkipIISCustomErrors flag. This will allow these responses to pass through when `existingResponse="Auto"`, while still allowing custom errors to be sent to clients for errors external to iisnode.